### PR TITLE
Add datasets_root to training config

### DIFF
--- a/config/train_nougat.yaml
+++ b/config/train_nougat.yaml
@@ -2,6 +2,7 @@ resume_from_checkpoint_path: null
 result_path: "result"
 model_path: null
 dataset_paths: ["path/to/train.jsonl"]
+datasets_root: "paired/output"
 tokenizer: "dataset/tokenizer.json"
 exp_name: "nougat"
 train_batch_sizes: [1]

--- a/train.py
+++ b/train.py
@@ -154,6 +154,7 @@ def train(config):
                     nougat_model=model_module.model,
                     max_length=config.max_length,
                     split=split,
+                    root_name=config.datasets_root
                 )
             )
     data_module.train_datasets = datasets["train"]


### PR DESCRIPTION
By default, the datasets root folder was the concatenation between the parent of the JSONL file and "arxiv", yet this folder name is not indicated in the datasets creation tutorial in the README, so this commit enables the user to choose any subfolder name for the datasets root.